### PR TITLE
Upper bound on python-gitlab (don't support 3.0.0)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ EXTRAS = {
 REQUIREMENTS = [
     "Jinja2>=2.10.3",
     "python-dateutil>=2.8.1",
-    "python-gitlab>=1.8.0",
+    "python-gitlab>=1.8.0, <3.0.0",
     "semver>=2.9.0",
 ]
 


### PR DESCRIPTION
Fixes CI failing #17 

Supporting python-gitlab 3.0.0 will require some work.